### PR TITLE
fix rdar://30011840 by setting definesPresentationContext

### DIFF
--- a/30011840 - SearchContentInset/SearchContentInset/Base.lproj/Main.storyboard
+++ b/30011840 - SearchContentInset/SearchContentInset/Base.lproj/Main.storyboard
@@ -55,7 +55,7 @@
         <!--Root View Controller-->
         <scene sceneID="hpP-pe-hDc">
             <objects>
-                <tableViewController id="PWT-EB-Ore" customClass="SearchTableViewController" sceneMemberID="viewController">
+                <tableViewController definesPresentationContext="YES" id="PWT-EB-Ore" customClass="SearchTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="OfH-qQ-F8c">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
I found out that definesPresentationContext should be set directly to
the content view controller that presents the search, not any parent
VC. See also the notes in my rdar://30100635