### PR TITLE
Fixed link to OpenRadar

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains most of our current radars. We can't share all samples
 because some might contain sensitive data or [PSPDFKit](https://pspdfkit.com/)
 source code, but we try to share as much as we can. The radar is also mirrored
-on [OpenRadar](openradar.appspot.com) and we keep a `README.md` file in each
+on [OpenRadar](https://openradar.appspot.com/) and we keep a `README.md` file in each
 folder to backup the text.
 
 Why so many radars? We have many customers and they often run into weird edge


### PR DESCRIPTION
Link is missing the protocol, so it tries to open it as a relative URL to the repo (e.g. https://github.com/PSPDFKit-labs/radar.apple.com/blob/master/openradar.appspot.com)